### PR TITLE
Correct declared and undeclared fault computations

### DIFF
--- a/actors/builtin/miner/deadlines.go
+++ b/actors/builtin/miner/deadlines.go
@@ -5,6 +5,8 @@ import (
 	"math"
 	"sort"
 
+	"golang.org/x/xerrors"
+
 	"github.com/filecoin-project/specs-actors/actors/abi"
 )
 
@@ -264,4 +266,19 @@ func AssignNewSectors(deadlines *Deadlines, partitionSize uint64, newSectors []u
 		sortDeadlines()
 	}
 	return nil
+}
+
+// FindDeadline returns the deadline index for a given sector number.
+// It returns an error if the sector number is not tracked by deadlines.
+func FindDeadline(deadlines *Deadlines, sectorNum abi.SectorNumber) (uint64, error) {
+	for deadlineIdx, sectorNums := range deadlines.Due {
+		found, err := sectorNums.IsSet(uint64(sectorNum))
+		if err != nil {
+			return 0, err
+		}
+		if found {
+			return uint64(deadlineIdx), nil
+		}
+	}
+	return 0, xerrors.New("sectorNum not due at any deadline")
 }

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -1839,10 +1839,7 @@ func unlockTerminationPenalty(st *State, store adt.Store, curEpoch abi.ChainEpoc
 // Returns the sum of the raw byte and quality-adjusted power for sectors.
 func PowerForSectors(sectorSize abi.SectorSize, sectors []*SectorOnChainInfo) (rawBytePower, qaPower big.Int) {
 	rawBytePower = big.Mul(big.NewIntUnsigned(uint64(sectorSize)), big.NewIntUnsigned(uint64(len(sectors))))
-	qaPower = big.Zero()
-	for _, s := range sectors {
-		qaPower = big.Add(qaPower, QAPowerForSector(sectorSize, s))
-	}
+	qaPower = qaPowerForSectors(sectorSize, sectors)
 	return
 }
 

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -1804,18 +1804,6 @@ func powerForSectors(sectorSize abi.SectorSize, sectors []*SectorOnChainInfo) (r
 	return
 }
 
-// This is the BR(t) value of the given sector for the current epoch.
-// It is the expected reward this sector would pay out over a one day period.
-// BR(t) = CurrEpochReward(t) * SectorQualityAdjustedPower * EpochsInDay / TotalNetworkQualityAdjustedPower(t)
-func expectedDayRewardForSector(rt Runtime, epochReward abi.TokenAmount, totalQAPower abi.StoragePower, sectorSize abi.SectorSize, sectorInfo *SectorOnChainInfo) abi.TokenAmount {
-	if totalQAPower.IsZero() {
-		rt.Abortf(exitcode.ErrIllegalState, "network has 0 QA power")
-	}
-	qaSectorPower := QAPowerForSector(sectorSize, sectorInfo)
-	expectedRewardForProvingPeriod := big.Mul(big.NewInt(builtin.EpochsInDay), epochReward)
-	return big.Div(big.Mul(qaSectorPower, expectedRewardForProvingPeriod), totalQAPower)
-}
-
 // The oldest seal challenge epoch that will be accepted in the current epoch.
 func sealChallengeEarliest(currEpoch abi.ChainEpoch, proof abi.RegisteredSealProof) abi.ChainEpoch {
 	return currEpoch - ChainFinality - MaxSealDuration[proof]

--- a/actors/builtin/miner/miner_actor.go
+++ b/actors/builtin/miner/miner_actor.go
@@ -4,12 +4,12 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
-	"github.com/pkg/errors"
 
 	addr "github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-bitfield"
 	cid "github.com/ipfs/go-cid"
 	cbg "github.com/whyrusleeping/cbor-gen"
+	"golang.org/x/xerrors"
 
 	abi "github.com/filecoin-project/specs-actors/actors/abi"
 	big "github.com/filecoin-project/specs-actors/actors/abi/big"
@@ -1810,7 +1810,7 @@ func unlockPenalty(st *State, store adt.Store, currEpoch abi.ChainEpoch, sectors
 	for _, s := range sectors {
 		sectorSize, err := s.Info.SealProof.SectorSize()
 		if err != nil {
-			return abi.NewTokenAmount(0), errors.Wrap(err, "could not get sector size for sector")
+			return abi.NewTokenAmount(0), xerrors.Errorf("could not get sector size for sector: %w", err)
 		}
 		fee = big.Add(fee, feeCalc(sectorSize, s))
 	}

--- a/actors/builtin/miner/miner_internal_test.go
+++ b/actors/builtin/miner/miner_internal_test.go
@@ -98,7 +98,7 @@ func TestFaultFeeInvariants(t *testing.T) {
 		networkPower := abi.NewStoragePower(100 << 50)
 		faultySectorPower := abi.NewStoragePower(1 << 50)
 
-		ff := pledgePenaltyForSectorDeclaredFault(epochReward, networkPower, faultySectorPower)
+		ff := PledgePenaltyForSectorDeclaredFault(epochReward, networkPower, faultySectorPower)
 		sp := pledgePenaltyForSectorUndeclaredFault(epochReward, networkPower, faultySectorPower)
 		assert.True(t, sp.GreaterThan(ff))
 	}) 
@@ -112,11 +112,11 @@ func TestFaultFeeInvariants(t *testing.T) {
 		totalFaultPower := big.Add(big.Add(faultySectorAPower, faultySectorBPower), faultySectorCPower)		
 
 		// Declared faults
-		ffA := pledgePenaltyForSectorDeclaredFault(epochReward, networkPower, faultySectorAPower)
-		ffB := pledgePenaltyForSectorDeclaredFault(epochReward, networkPower, faultySectorBPower)		
-		ffC := pledgePenaltyForSectorDeclaredFault(epochReward, networkPower, faultySectorCPower)				
+		ffA := PledgePenaltyForSectorDeclaredFault(epochReward, networkPower, faultySectorAPower)
+		ffB := PledgePenaltyForSectorDeclaredFault(epochReward, networkPower, faultySectorBPower)		
+		ffC := PledgePenaltyForSectorDeclaredFault(epochReward, networkPower, faultySectorCPower)				
 
-		ffAll := pledgePenaltyForSectorDeclaredFault(epochReward, networkPower, totalFaultPower)
+		ffAll := PledgePenaltyForSectorDeclaredFault(epochReward, networkPower, totalFaultPower)
 
 		// Because we can introduce rounding error between 1 and zero for every penalty calculation
 		// we can at best expect n calculations of 1 power to be within n of 1 calculation of n powers.

--- a/actors/builtin/miner/miner_internal_test.go
+++ b/actors/builtin/miner/miner_internal_test.go
@@ -98,8 +98,8 @@ func TestFaultFeeInvariants(t *testing.T) {
 		networkPower := abi.NewStoragePower(100 << 50)
 		faultySectorPower := abi.NewStoragePower(1 << 50)
 
-		ff := PledgePenaltyForSectorDeclaredFault(epochReward, networkPower, faultySectorPower)
-		sp := pledgePenaltyForSectorUndeclaredFault(epochReward, networkPower, faultySectorPower)
+		ff := PledgePenaltyForDeclaredFault(epochReward, networkPower, faultySectorPower)
+		sp := PledgePenaltyForUndeclaredFault(epochReward, networkPower, faultySectorPower)
 		assert.True(t, sp.GreaterThan(ff))
 	}) 
 
@@ -112,11 +112,11 @@ func TestFaultFeeInvariants(t *testing.T) {
 		totalFaultPower := big.Add(big.Add(faultySectorAPower, faultySectorBPower), faultySectorCPower)		
 
 		// Declared faults
-		ffA := PledgePenaltyForSectorDeclaredFault(epochReward, networkPower, faultySectorAPower)
-		ffB := PledgePenaltyForSectorDeclaredFault(epochReward, networkPower, faultySectorBPower)		
-		ffC := PledgePenaltyForSectorDeclaredFault(epochReward, networkPower, faultySectorCPower)				
+		ffA := PledgePenaltyForDeclaredFault(epochReward, networkPower, faultySectorAPower)
+		ffB := PledgePenaltyForDeclaredFault(epochReward, networkPower, faultySectorBPower)		
+		ffC := PledgePenaltyForDeclaredFault(epochReward, networkPower, faultySectorCPower)				
 
-		ffAll := PledgePenaltyForSectorDeclaredFault(epochReward, networkPower, totalFaultPower)
+		ffAll := PledgePenaltyForDeclaredFault(epochReward, networkPower, totalFaultPower)
 
 		// Because we can introduce rounding error between 1 and zero for every penalty calculation
 		// we can at best expect n calculations of 1 power to be within n of 1 calculation of n powers.
@@ -125,11 +125,11 @@ func TestFaultFeeInvariants(t *testing.T) {
 		assert.True(t, diff.LessThan(big.NewInt(3)))
 
 		// Undeclared faults		
-		spA := pledgePenaltyForSectorUndeclaredFault(epochReward, networkPower, faultySectorAPower)
-		spB := pledgePenaltyForSectorUndeclaredFault(epochReward, networkPower, faultySectorBPower)		
-		spC := pledgePenaltyForSectorUndeclaredFault(epochReward, networkPower, faultySectorCPower)				
+		spA := PledgePenaltyForUndeclaredFault(epochReward, networkPower, faultySectorAPower)
+		spB := PledgePenaltyForUndeclaredFault(epochReward, networkPower, faultySectorBPower)		
+		spC := PledgePenaltyForUndeclaredFault(epochReward, networkPower, faultySectorCPower)				
 
-		spAll := pledgePenaltyForSectorUndeclaredFault(epochReward, networkPower, totalFaultPower)
+		spAll := PledgePenaltyForUndeclaredFault(epochReward, networkPower, totalFaultPower)
 
 		// Because we can introduce rounding error between 1 and zero for every penalty calculation
 		// we can at best expect n calculations of 1 power to be within n of 1 calculation of n powers.

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -834,9 +834,13 @@ func (h *actorHarness) declareFaults(rt *mock.Runtime, faultSectorInfos ...*mine
 	ss, err := faultSectorInfos[0].Info.SealProof.SectorSize()
 	require.NoError(h.t, err)
 	expectedRawDelta, expectedQADelta := miner.PowerForSectors(ss, faultSectorInfos)
+	expectedRawDelta = big.Mul(big.NewInt(-1), expectedRawDelta)
+	expectedQADelta = big.Mul(big.NewInt(-1), expectedQADelta)
 
 	expectedReward := abi.NewTokenAmount(100_000)
-	expectedTotalPower := big.Mul(big.NewInt(10), expectedQADelta)
+	expectedTotalPower := power.CurrentTotalPowerReturn{
+		QualityAdjPower: big.Mul(big.NewInt(10), expectedQADelta),
+	}
 
 	rt.ExpectSend(
 		builtin.RewardActorAddr, 
@@ -866,7 +870,7 @@ func (h *actorHarness) declareFaults(rt *mock.Runtime, faultSectorInfos ...*mine
 		exitcode.Ok,
 	)
 
-	fee := miner.PledgePenaltyForSectorDeclaredFault(expectedReward, expectedTotalPower, expectedQADelta)
+	fee := miner.PledgePenaltyForSectorDeclaredFault(expectedReward, expectedTotalPower.QualityAdjPower, expectedQADelta)
 	// expect fee
 	rt.ExpectSend(
 		builtin.BurntFundsActorAddr,

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -731,6 +731,14 @@ func (h *actorHarness) submitWindowPost(rt *mock.Runtime, deadline *miner.Deadli
 	rt.SetCaller(h.worker, builtin.AccountActorCodeID)
 	rt.ExpectValidateCallerAddr(h.worker)
 
+	reward := big.NewIntUnsigned(1e18)
+	rt.ExpectSend(builtin.RewardActorAddr, builtin.MethodsReward.LastPerEpochReward, nil, big.Zero(), &reward, exitcode.Ok)
+
+	pwrTotal := power.CurrentTotalPowerReturn{
+		QualityAdjPower: big.NewIntUnsigned(1000),
+	}
+	rt.ExpectSend(builtin.StoragePowerActorAddr, builtin.MethodsPower.CurrentTotalPower, nil, big.Zero(), &pwrTotal, exitcode.Ok)
+
 	var registeredPoStProof, err = abi.RegisteredSealProof_StackedDrg2KiBV1.RegisteredWindowPoStProof()
 	require.NoError(h.t, err)
 
@@ -848,6 +856,13 @@ func (h *actorHarness) onProvingPeriodCron(rt *mock.Runtime, expectedEnrollment 
 		rt.ExpectGetRandomness(crypto.DomainSeparationTag_WindowedPoStDeadlineAssignment, randEpoch, nil, bytes.Repeat([]byte{0}, 32))
 	}
 	// Re-enrollment for next period.
+	reward := big.NewIntUnsigned(1e18)
+	rt.ExpectSend(builtin.RewardActorAddr, builtin.MethodsReward.LastPerEpochReward, nil, big.Zero(), &reward, exitcode.Ok)
+
+	pwrTotal := power.CurrentTotalPowerReturn{
+		QualityAdjPower: big.NewIntUnsigned(1000),
+	}
+	rt.ExpectSend(builtin.StoragePowerActorAddr, builtin.MethodsPower.CurrentTotalPower, nil, big.Zero(), &pwrTotal, exitcode.Ok)
 	rt.ExpectSend(builtin.StoragePowerActorAddr, builtin.MethodsPower.EnrollCronEvent,
 		makeProvingPeriodCronEventParams(h.t, expectedEnrollment), big.Zero(), nil, exitcode.Ok)
 	rt.SetCaller(builtin.StoragePowerActorAddr, builtin.StoragePowerActorCodeID)

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -424,6 +424,25 @@ func TestProvingPeriodCron(t *testing.T) {
 	})
 }
 
+func TestDeclareFaults(t *testing.T) {
+	owner := tutil.NewIDAddr(t, 100)
+	worker := tutil.NewIDAddr(t, 101)
+	workerKey := tutil.NewBLSAddr(t, 0)
+	actor := newHarness(t, tutil.NewIDAddr(t, 1000), owner, worker, workerKey)
+	periodOffset := abi.ChainEpoch(100)
+	builder := mock.NewBuilder(context.Background(), actor.receiver).
+		WithActorType(owner, builtin.AccountActorCodeID).
+		WithActorType(worker, builtin.AccountActorCodeID).
+		WithHasher(fixedHasher(uint64(periodOffset))).
+		WithCaller(builtin.InitActorAddr, builtin.InitActorCodeID).
+		WithBalance(big.Mul(big.NewInt(1000), big.NewInt(1e18)), big.Zero())
+
+	t.Run("declare fault", func(t *testing.T) {
+		rt := builder.Build(t)
+
+	})
+}
+
 func TestExtendSectorExpiration(t *testing.T) {
 	owner := tutil.NewIDAddr(t, 100)
 	worker := tutil.NewIDAddr(t, 101)

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -735,7 +735,7 @@ func (h *actorHarness) submitWindowPost(rt *mock.Runtime, deadline *miner.Deadli
 	rt.ExpectSend(builtin.RewardActorAddr, builtin.MethodsReward.LastPerEpochReward, nil, big.Zero(), &reward, exitcode.Ok)
 
 	pwrTotal := power.CurrentTotalPowerReturn{
-		QualityAdjPower: big.NewIntUnsigned(1000),
+		QualityAdjPower: big.NewIntUnsigned(1 << 50),
 	}
 	rt.ExpectSend(builtin.StoragePowerActorAddr, builtin.MethodsPower.CurrentTotalPower, nil, big.Zero(), &pwrTotal, exitcode.Ok)
 
@@ -860,7 +860,7 @@ func (h *actorHarness) onProvingPeriodCron(rt *mock.Runtime, expectedEnrollment 
 	rt.ExpectSend(builtin.RewardActorAddr, builtin.MethodsReward.LastPerEpochReward, nil, big.Zero(), &reward, exitcode.Ok)
 
 	pwrTotal := power.CurrentTotalPowerReturn{
-		QualityAdjPower: big.NewIntUnsigned(1000),
+		QualityAdjPower: big.NewIntUnsigned(1 << 50),
 	}
 	rt.ExpectSend(builtin.StoragePowerActorAddr, builtin.MethodsPower.CurrentTotalPower, nil, big.Zero(), &pwrTotal, exitcode.Ok)
 	rt.ExpectSend(builtin.StoragePowerActorAddr, builtin.MethodsPower.EnrollCronEvent,

--- a/actors/builtin/miner/miner_test.go
+++ b/actors/builtin/miner/miner_test.go
@@ -464,7 +464,7 @@ func TestDeclareFaults(t *testing.T) {
 		_, sectorQAPower := miner.PowerForSectors(ss, []*miner.SectorOnChainInfo{info})
 		expectedReward := big.Exp(big.NewInt(10), big.NewInt(18)) // 1 FIL
 		totalQAPower := big.NewInt(1 << 52)
-		fee := miner.PledgePenaltyForSectorDeclaredFault(expectedReward, totalQAPower, sectorQAPower)
+		fee := miner.PledgePenaltyForDeclaredFault(expectedReward, totalQAPower, sectorQAPower)
 
 		actor.declareFaults(rt, expectedReward, totalQAPower, fee, info)
 	})

--- a/actors/builtin/miner/monies.go
+++ b/actors/builtin/miner/monies.go
@@ -29,7 +29,7 @@ func ExpectedDayRewardForSector(epochTargetReward abi.TokenAmount, networkQAPowe
 // This is the FF(t) penalty for a sector expected to be in the fault state either because the fault was declared or because
 // it has been previously detected by the network.
 // FF(t) = DeclaredFaultFactor * BR(t)
-func pledgePenaltyForSectorDeclaredFault(epochTargetReward abi.TokenAmount, networkQAPower abi.StoragePower, qaSectorPower abi.StoragePower) abi.TokenAmount {
+func PledgePenaltyForSectorDeclaredFault(epochTargetReward abi.TokenAmount, networkQAPower abi.StoragePower, qaSectorPower abi.StoragePower) abi.TokenAmount {
 	return big.Div(
 		big.Mul(DeclaredFaultFactorNum, ExpectedDayRewardForSector(epochTargetReward, networkQAPower, qaSectorPower)),
 		DeclaredFaultFactorDenom)

--- a/actors/builtin/miner/monies.go
+++ b/actors/builtin/miner/monies.go
@@ -3,7 +3,18 @@ package miner
 import (
 	"github.com/filecoin-project/specs-actors/actors/abi"
 	"github.com/filecoin-project/specs-actors/actors/abi/big"
+	"github.com/filecoin-project/specs-actors/actors/builtin"
+	"github.com/filecoin-project/specs-actors/actors/util"
 )
+
+// This is the BR(t) value of the given sector for the current epoch.
+// It is the expected reward this sector would pay out over a one day period.
+// BR(t) = CurrEpochReward(t) * SectorQualityAdjustedPower * EpochsInDay / TotalNetworkQualityAdjustedPower(t)
+func ExpectedDayRewardForSector(epochTargetReward abi.TokenAmount, networkQAPower abi.StoragePower, qaSectorPower abi.StoragePower) abi.TokenAmount {
+	util.Assert(!networkQAPower.IsZero())
+	expectedRewardForProvingPeriod := big.Mul(big.NewInt(builtin.EpochsInDay), epochTargetReward)
+	return big.Div(big.Mul(qaSectorPower, expectedRewardForProvingPeriod), networkQAPower)
+}
 
 // Computes the pledge requirement for committing new quality-adjusted power to the network, given the current
 // total power, total pledge commitment, epoch block reward, and circulating token supply.
@@ -11,7 +22,7 @@ import (
 // newly-committed power, holding the per-epoch block reward constant (though in reality it will change over time).
 // The network total pledge and circulating supply parameters are currently unused, but may be included in a
 // future calculation.
-func InitialPledgeForPower(newQAPower abi.StoragePower, networkQAPower abi.StoragePower, networkTotalPledge abi.TokenAmount, epochTargetReward abi.TokenAmount, networkCirculatingSupply abi.TokenAmount) abi.TokenAmount {
+func InitialPledgeForPower(qaSectorPower abi.StoragePower, networkQAPower abi.StoragePower, networkTotalPledge abi.TokenAmount, epochTargetReward abi.TokenAmount, networkCirculatingSupply abi.TokenAmount) abi.TokenAmount {
 	// Details here are still subject to change.
 	// PARAM_FINISH
 	// https://github.com/filecoin-project/specs-actors/issues/468
@@ -21,6 +32,5 @@ func InitialPledgeForPower(newQAPower abi.StoragePower, networkQAPower abi.Stora
 	if networkQAPower.IsZero() {
 		return epochTargetReward
 	}
-	return big.Div(big.Mul(newQAPower, epochTargetReward), networkQAPower)
+	return big.Mul(big.NewInt(20), ExpectedDayRewardForSector(epochTargetReward, networkQAPower, qaSectorPower))
 }
-

--- a/actors/builtin/miner/policy.go
+++ b/actors/builtin/miner/policy.go
@@ -142,21 +142,6 @@ type BigFrac struct {
 	denominator big.Int
 }
 
-// Penalty to locked pledge collateral for the termination of a sector before scheduled expiry.
-func pledgePenaltyForSectorTermination(sector *SectorOnChainInfo) abi.TokenAmount {
-	return big.Zero() // PARAM_FINISH
-}
-
-// Penalty to locked pledge collateral for a "skipped" sector or missing PoSt fault.
-func pledgePenaltyForSectorUndeclaredFault(sector *SectorOnChainInfo) abi.TokenAmount {
-	return big.Zero() // PARAM_FINISH
-}
-
-// Penalty to locked pledge collateral for a declared or on-going sector fault.
-func pledgePenaltyForSectorDeclaredFault(sector *SectorOnChainInfo) abi.TokenAmount {
-	return big.Zero() // PARAM_FINISH
-}
-
 var consensusFaultReporterInitialShare = BigFrac{
 	// PARAM_FINISH
 	numerator:   big.NewInt(1),


### PR DESCRIPTION
partially addresses #437
closes #468

### Motivation

We have not been using the right calculation for fault penalties. This PR:

1. Moves the calculation logic into the monies.go file.
2. Extracts `ExpectedDayRewardForSector` as the basis for all penalty calculations.
3. Implents `pledgePenaltyForSectorDeclaredFault`, `pledgePenaltyForSectorUndeclaredFault`, and `InitialPledgeForPower` according to the latest understanding from slash the world.
4. Adds calls to get `epochReward` from reward actor and `totalPwr` from power actor to miner calls that now need them to compute penalties.
5. Modify penalty calls in miner actor to use the new logic.
6. Modify tests to expect new extra calls to reward and power actor.

### Work left undone

Issue #437 talks of both fault fees and sector termination fees. This work only covers the former. Sector termination will be covered in a future PR.